### PR TITLE
最低限のバグ修正と#2の再追加

### DIFF
--- a/appremove.sh
+++ b/appremove.sh
@@ -3,7 +3,7 @@
 # adb install
 if ! which adb >/dev/null 2>&1 ; then
   if [ "$(uname)" = 'Darwin' ]; then
-    cd "${HOME}"
+    cd "${HOME}" || exit 1
     curl -L --output "$TMPDIR/platform-tools.zip" "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
     unzip "$TMPDIR/platform-tools.zip"
     mv "${TMPDIR}/platform-tools/" "${HOME}/Applications/"

--- a/appremove.sh
+++ b/appremove.sh
@@ -30,7 +30,7 @@ adb shell exit > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   adb shell pm list package | sed -e "s/package://g" | grep -e 'docomo' -e 'ntt' -e 'auone' -e 'rakuten' -e 'kddi' -e 'softbank' | sed "s@^@adb shell pm uninstall --user 0 @g" > test.sh
   cat test.sh | sed -e "s@adb shell pm uninstall --user 0@@g"
-  echo `cat test.sh | wc -l` "個のアプリが消去されます [Y/n]: "
+  echo "$(wc -l < test.sh)個のアプリが消去されます [Y/n]: "
   read ANS
   case $ANS in
     "" | [Yy]* )

--- a/appremove.sh
+++ b/appremove.sh
@@ -7,9 +7,9 @@ if [ $? -ne 0 ] ; then
     unzip "$TMPDIR/platform-tools.zip"
     mv "${TMPDIR}platform-tools/" "${HOME}/Applications/"
     rm -f "$TMPDIR/platform-tools.zip"
-    export PATH="$PATH:`pwd`/Applications/platform-tools"
-    touch ~/.zshrc && echo export PATH="$PATH:`pwd`/Applications/platform-tools" >> .zshrc
-    touch ~/.bashrc && echo export PATH="$PATH:`pwd`/Applications/platform-tools" >> .bashrc
+    export PATH="$PATH:$(pwd)/Applications/platform-tools"
+    touch ~/.zshrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .zshrc
+    touch ~/.bashrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .bashrc
     #source ~/.zshrc
   elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
     sudo apt update && sudo apt install adb fastboot -y

--- a/appremove.sh
+++ b/appremove.sh
@@ -9,8 +9,8 @@ if ! which adb >/dev/null 2>&1 ; then
     mv "${TMPDIR}/platform-tools/" "${HOME}/Applications/"
     rm -f "$TMPDIR/platform-tools.zip"
     export PATH="$PATH:$(pwd)/Applications/platform-tools"
-    touch ~/.zshrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .zshrc
-    touch ~/.bashrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .bashrc
+    touch ~/.zshrc && echo export PATH="$PATH" >> .zshrc
+    touch ~/.bashrc && echo export PATH="$PATH" >> .bashrc
     #source ~/.zshrc
   elif [ "$(expr substr $(uname -s) 1 5)" = 'Linux' ]; then
     sudo apt update && sudo apt install adb fastboot -y

--- a/appremove.sh
+++ b/appremove.sh
@@ -31,8 +31,8 @@ if [ $? -eq 0 ]; then
   adb shell pm list package | sed -e "s/package://g" | grep -e 'docomo' -e 'ntt' -e 'auone' -e 'rakuten' -e 'kddi' -e 'softbank' | sed "s@^@adb shell pm uninstall --user 0 @g" > test.sh
   cat test.sh | sed -e "s@adb shell pm uninstall --user 0@@g"
   echo "$(wc -l < test.sh)個のアプリが消去されます [Y/n]: "
-  read ANS
-  case $ANS in
+  read -r ANS
+  case "${ANS}" in
     "" | [Yy]* )
       bash test.sh
       rm test.sh

--- a/appremove.sh
+++ b/appremove.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-which adb >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
+
+# adb install
+if ! which adb >/dev/null 2>&1 ; then
   if [ "$(uname)" = 'Darwin' ]; then
     cd "${HOME}"
     curl -L --output "$TMPDIR/platform-tools.zip" "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"

--- a/appremove.sh
+++ b/appremove.sh
@@ -19,11 +19,11 @@ if ! which adb >/dev/null 2>&1 ; then
     if [ $? -eq 0 ]; then
       echo "成功しました"
     else
-      echo "adbのインストールに失敗しました。"
+      echo "adbのインストールに失敗しました。" >&2
       exit 1
     fi
   else
-    echo "このOSは非対応です"
+    echo "このOSは非対応です" >&2
     exit 1
   fi
 fi
@@ -46,6 +46,6 @@ if adb shell exit > /dev/null 2>&1; then
       ;;
     esac
 else
-  echo "USBデバッグが有効なデバイスが見つかりません。"
-  echo "Android端末が正しく接続されているか確認してください"
+  echo "USBデバッグが有効なデバイスが見つかりません。" >&2
+  echo "Android端末が正しく接続されているか確認してください" >&2
 fi

--- a/appremove.sh
+++ b/appremove.sh
@@ -28,8 +28,8 @@ if ! which adb >/dev/null 2>&1 ; then
   fi
 fi
 adb kill-server > /dev/null 2>&1
-adb shell exit > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+
+if adb shell exit > /dev/null 2>&1; then
   adb shell pm list package | sed -e "s/package://g" | grep -e 'docomo' -e 'ntt' -e 'auone' -e 'rakuten' -e 'kddi' -e 'softbank' | sed "s@^@adb shell pm uninstall --user 0 @g" > test.sh
   sed -e "s@adb shell pm uninstall --user 0@@g" test.sh
   echo "$(wc -l < test.sh)個のアプリが消去されます [Y/n]: "
@@ -45,7 +45,7 @@ if [ $? -eq 0 ]; then
       echo "処理を中止しました。"
       ;;
     esac
-elif [ $? -eq 1 ]; then
+else
   echo "USBデバッグが有効なデバイスが見つかりません。"
   echo "Android端末が正しく接続されているか確認してください"
 fi

--- a/appremove.sh
+++ b/appremove.sh
@@ -29,7 +29,7 @@ adb kill-server > /dev/null 2>&1
 adb shell exit > /dev/null 2>&1
 if [ $? -eq 0 ]; then
   adb shell pm list package | sed -e "s/package://g" | grep -e 'docomo' -e 'ntt' -e 'auone' -e 'rakuten' -e 'kddi' -e 'softbank' | sed "s@^@adb shell pm uninstall --user 0 @g" > test.sh
-  cat test.sh | sed -e "s@adb shell pm uninstall --user 0@@g"
+  sed -e "s@adb shell pm uninstall --user 0@@g" test.sh
   echo "$(wc -l < test.sh)個のアプリが消去されます [Y/n]: "
   read -r ANS
   case "${ANS}" in

--- a/appremove.sh
+++ b/appremove.sh
@@ -10,7 +10,7 @@ if ! which adb >/dev/null 2>&1 ; then
     unzip "$TMPDIR/platform-tools.zip"
     mv "${TMPDIR}/platform-tools/" "${HOME}/Applications/"
     rm -f "$TMPDIR/platform-tools.zip"
-    export PATH="$PATH:$(pwd)/Applications/platform-tools"
+    export PATH="$PATH:${HOME}/Applications/platform-tools"
     touch ~/.zshrc && echo export PATH="$PATH" >> .zshrc
     touch ~/.bashrc && echo export PATH="$PATH" >> .bashrc
     #source ~/.zshrc

--- a/appremove.sh
+++ b/appremove.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 which adb >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
-  if [ "$(uname)" == 'Darwin' ]; then
+  if [ "$(uname)" = 'Darwin' ]; then
     cd "${HOME}"
     curl -L --output "$TMPDIR/platform-tools.zip" "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
     unzip "$TMPDIR/platform-tools.zip"
@@ -11,7 +11,7 @@ if [ $? -ne 0 ] ; then
     touch ~/.zshrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .zshrc
     touch ~/.bashrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .bashrc
     #source ~/.zshrc
-  elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
+  elif [ "$(expr substr $(uname -s) 1 5)" = 'Linux' ]; then
     sudo apt update && sudo apt install adb fastboot -y
     if [ $? -eq 0 ]; then
       echo "成功しました"

--- a/appremove.sh
+++ b/appremove.sh
@@ -2,15 +2,15 @@
 which adb >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
   if [ "$(uname)" == 'Darwin' ]; then
-    cd ~/
-    curl -OL https://dl.google.com/android/repository/platform-tools_r33.0.1-darwin.zip
-    unzip platform-tools_r33.0.1-darwin.zip
-    mv platform-tools/ ~/Applications/
-    rm platform-tools_r33.0.1-darwin.zip
+    cd "${HOME}"
+    curl -L --output "$TMPDIR/platform-tools.zip" "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
+    unzip "$TMPDIR/platform-tools.zip"
+    mv "${TMPDIR}platform-tools/" "${HOME}/Applications/"
+    rm -f "$TMPDIR/platform-tools.zip"
     export PATH="$PATH:`pwd`/Applications/platform-tools"
     touch ~/.zshrc && echo export PATH="$PATH:`pwd`/Applications/platform-tools" >> .zshrc
     touch ~/.bashrc && echo export PATH="$PATH:`pwd`/Applications/platform-tools" >> .bashrc
-    source ~/.zshrc
+    #source ~/.zshrc
   elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
     sudo apt update && sudo apt install adb fastboot -y
     if [ $? -eq 0 ]; then

--- a/appremove.sh
+++ b/appremove.sh
@@ -6,7 +6,7 @@ if ! which adb >/dev/null 2>&1 ; then
     cd "${HOME}"
     curl -L --output "$TMPDIR/platform-tools.zip" "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
     unzip "$TMPDIR/platform-tools.zip"
-    mv "${TMPDIR}platform-tools/" "${HOME}/Applications/"
+    mv "${TMPDIR}/platform-tools/" "${HOME}/Applications/"
     rm -f "$TMPDIR/platform-tools.zip"
     export PATH="$PATH:$(pwd)/Applications/platform-tools"
     touch ~/.zshrc && echo export PATH="$PATH:$(pwd)/Applications/platform-tools" >> .zshrc

--- a/appremove.sh
+++ b/appremove.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 # adb install
 if ! which adb >/dev/null 2>&1 ; then
   if [ "$(uname)" = 'Darwin' ]; then


### PR DESCRIPTION
# 現在確認できるすべてのバグの修正

## #2 について
#2 のインストール処理の部分で、入力ミスがあったので修正しました。多分それが理由で動かなかった？

`mv "${TMPDIR}platform-tools/" "${HOME}/Applications/"` 
↓
`mv "${TMPDIR}/platform-tools/" "${HOME}/Applications/"`

## そのほかの修正点

- コマンド展開に` `` `の代わりに`$()`を使ってください（[詳細](https://github.com/koalaman/shellcheck/wiki/SC2006)）
- POSIX Shellでは`==`は利用できません（#!/bin/shはPOSIX準拠です）（[詳細](https://github.com/koalaman/shellcheck/wiki/SC3014)）
- `if`文はコマンドの終了コードを判定するためのものなので、if文で`$?`を比較するのは不自然な構文です。
   また、間に別の文挟まると破綻するため、適切ではありません
- 既に環境変数をexportしているので、ファイルに追記する際にさらに加える必要はありません
- `cd`はディレクトリが存在しない場合の処理を記述するべきです（[詳細](https://github.com/koalaman/shellcheck/wiki/SC302164)）
- `wc`でファイルの行数をカウントする際にcatとパイプを利用するのは適切な記述方法ではありません
   代わりに`<`を利用してファイルの内容を直接標準入力に渡します
- `read`コマンドはほとんどの場合で`-r`をつけるべきです（[詳細](https://github.com/koalaman/shellcheck/wiki/SC2162)）
- `sed`はコマンドの用法としてファイルを指定することができるので、`cat`と併用する必要はありません
- `set -eu`を利用して、途中のコマンドが異常終了したり未定義変数を参照した際にスクリプトを終了させます
   これによって予期せぬコマンドの異常が発生した危険な状態でのスクリプトの続行を制限します。
- `cd ~/`してから`$(pwd)`でカレントディレクトリを参照するよりも、環境変数`$HOME`を参照した方が確実で安全です。
- エラーメッセージは標準エラー出力に出力するべきなので、`>&2`を利用してリダイレクトします