### PR TITLE
Arch系、Redhat系、VoidLinuxでも依存関係を自動で解決するように変更

### DIFF
--- a/appremove.sh
+++ b/appremove.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ] ; then
     elif command -v apt &> /dev/null ; then
       sudo apt update && sudo apt install adb fastboot -y
     elif command -v xbps-install &> /dev/null ; then
-      sudo xbps-install -S -y xbps && sudo xbps-install -Su -y android-tools
+      sudo xbps-install -S -y xbps && sudo xbps-install -S -y android-tools
     elif command -v yum &> /dev/null ; then
       sudo yum makecache && sudo yum -y install android-tools
     elif command -v dnf &> /dev/null ; then

--- a/appremove.sh
+++ b/appremove.sh
@@ -16,6 +16,8 @@ if [ $? -ne 0 ] ; then
       sudo pacman -Sy --noconfirm android-tools
     elif command -v apt &> /dev/null ; then
       sudo apt update && sudo apt install adb fastboot -y
+    elif command -v xbps-install &> /dev/null ; then
+      sudo xbps-install -Su android-tools
     fi
     if [ $? -eq 0 ]; then
       echo "成功しました"

--- a/appremove.sh
+++ b/appremove.sh
@@ -18,6 +18,10 @@ if [ $? -ne 0 ] ; then
       sudo apt update && sudo apt install adb fastboot -y
     elif command -v xbps-install &> /dev/null ; then
       sudo xbps-install -Su android-tools
+    elif command -v yum &> /dev/null ; then
+      sudo yum makecache && sudo yum -y install android-tools
+    elif command -v dnf &> /dev/null ; then
+      sudo dnf makecache && sudo dnf -y install android-tools
     fi
     if [ $? -eq 0 ]; then
       echo "成功しました"

--- a/appremove.sh
+++ b/appremove.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ] ; then
     elif command -v apt &> /dev/null ; then
       sudo apt update && sudo apt install adb fastboot -y
     elif command -v xbps-install &> /dev/null ; then
-      sudo xbps-install -Su android-tools
+      sudo xbps-install -S -y xbps && sudo xbps-install -Su -y android-tools
     elif command -v yum &> /dev/null ; then
       sudo yum makecache && sudo yum -y install android-tools
     elif command -v dnf &> /dev/null ; then

--- a/appremove.sh
+++ b/appremove.sh
@@ -12,7 +12,11 @@ if [ $? -ne 0 ] ; then
     touch ~/.bashrc && echo export PATH="$PATH:`pwd`/Applications/platform-tools" >> .bashrc
     source ~/.zshrc
   elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
-    sudo apt update && sudo apt install adb fastboot -y
+    if command -v pacman &> /dev/null ; then
+      sudo pacman -Sy --noconfirm android-tools
+    elif command -v apt &> /dev/null ; then
+      sudo apt update && sudo apt install adb fastboot -y
+    fi
     if [ $? -eq 0 ]; then
       echo "成功しました"
     else


### PR DESCRIPTION
Arch系、Redhat系、VoidLinuxでも依存関係を自動で解決するように変更しました。
Manjaro、Fedora35、VoidLinux、Ubuntu20.04で動作確認済み